### PR TITLE
Fail gracefully if config not found, disable proxy by default

### DIFF
--- a/config/config.yaml.dist
+++ b/config/config.yaml.dist
@@ -1,5 +1,5 @@
 # Connection details for proxy
-Proxy:  True
+Proxy:  False
 ProxyURL: "127.0.0.1:8008"
 RewardAddress:  "0x0000000000000000000000000000000000000001"
 Password: "password"

--- a/main.go
+++ b/main.go
@@ -128,7 +128,8 @@ func main() {
 	// Load config
 	config, err := util.LoadConfig("..")
 	if err != nil {
-		log.Fatal("cannot load config:", err)
+		log.Print("Could not load config: ", err)
+		return
 	}
 	// Parse mining location from args
 	if len(os.Args) > 2 {

--- a/util/config.go
+++ b/util/config.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	"fmt"
-
 	"github.com/dominant-strategies/go-quai/common"
 	"github.com/spf13/viper"
 )
@@ -28,9 +26,9 @@ func LoadConfig(path string) (config Config, err error) {
 	err = viper.ReadInConfig()    // Find and read the config file
 
 	if err != nil { // Handle errors reading the config file
-		panic(fmt.Errorf("Fatal error config file: %w \n", err))
+		return config, err
 	}
 
 	err = viper.Unmarshal(&config)
-	return
+	return config, err
 }


### PR DESCRIPTION
Instead of panicking, display an error message when the config isn't found.
Also most users will probably run without a proxy at first, so by default its disabled.